### PR TITLE
kubernetes_check status payload fix

### DIFF
--- a/masakarimonitors/hostmonitor/kubernetes_check/manager.py
+++ b/masakarimonitors/hostmonitor/kubernetes_check/manager.py
@@ -81,6 +81,7 @@ class KubernetesCheck(driver.DriverBase):
 
     @staticmethod
     def _event(host, host_health):
+        host_status = ec.EventConstants.HOST_STATUS_NORMAL
         LOG.info("Host %s needs recovery, health status: %s." %
                  (host, host_health))
 
@@ -90,7 +91,8 @@ class KubernetesCheck(driver.DriverBase):
                 'hostname': host,
                 'generated_time': timeutils.utcnow(),
                 'payload': {
-                    'event': ec.EventConstants.EVENT_STOPPED
+                    'event': ec.EventConstants.EVENT_STOPPED,
+                    'host_status': host_status
                 }
             }
         }


### PR DESCRIPTION
Payload data from masakari-host-monitor process was missing the host_status parameter to allow the masakari-engine to initiate the recovery workflow message to the API server, previous payload would be ignored by masakari-engine workflow driver.

EXPECTED:

Host will initiate a host failover recovery workflow when threashold of kubernetes_check monitor driver is triggered.                                      


RESULT: 

Recovery is ignored on a host-failure, masakari-monitor host-monitor will create a notification but is missing the host_status payload parameter data.

masakari-host-monitor log

masakari-host-monitor 2025-05-18 22:48:04.854 1 INFO masakarimonitors.ha.masakari [-] Send a notification. {'notification': {'type': 'COMPUTE_HOST', 'hostname': 'compute02.maas', 'generated_time': datetime.date │
│ time(2025, 5, 18, 22, 48, 4, 854095), 'payload': {'event': 'STOPPED'}}}


+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| created_at                | 2025-05-18T22:48:04.000000           |
| updated_at                | 2025-05-18T22:48:05.000000           |
| notification_uuid         | 8c4d0d17-8ed6-4e85-ad69-5e7753129b25 |
| type                      | COMPUTE_HOST                         |
| status                    | ignored                              |
| source_host_uuid          | b91c0122-0d19-414c-aa5f-e360e297375d |
| generated_time            | 2025-05-18T22:48:03.000000           |
| payload                   | {'event': 'STOPPED'}                 |
| recovery_workflow_details | []                                   |
+---------------------------+--------------------------------------+
